### PR TITLE
Fix: update article tag links to use dynamic query filter

### DIFF
--- a/_layouts/article.html
+++ b/_layouts/article.html
@@ -143,7 +143,7 @@ script_includes:
         <i class="fa fa-tags fa-fw me-1"></i>
         {% for tag in page.tags %}
           <a
-            href="{{ site.baseurl }}/tags/{{ tag | slugify | url_encode }}/"
+            href="{{ site.baseurl }}/tag/?tag={{ tag | url_encode }}"
             class="post-tag no-text-decoration"
           >
             {{- tag -}}


### PR DESCRIPTION
### 🏷️ Change Type

*Use 'x' to mark the type of change that applies to this Pull Request. This should align with your branch prefix:*

- [x] `feature/`: New features, enhancements, or improvements.
- [ ] `fix/`: Bug fixes or small corrections.
- [ ] `hotfix/`: Urgent fixes applied directly to production.
- [ ] `chore/`: Maintenance tasks or general cleanup (no code logic change).
- [ ] `refactor/`: Restructuring or improving code without changing its behavior.
- [ ] `docs/`: Documentation changes or improvements.
- [ ] `test/`: Adding or updating automated tests.
- [ ] `release/`: Preparing a new release version.
- [ ] `ci/`: Continuous integration, pipeline, or automation scripts.
- [ ] `perf/`: Performance improvements.
- [ ] `style/`: Formatting, indentation, or code style adjustments.

---

### 📝 Description of Changes

This PR resolves an incorrect link destination (`href`) for tags displayed within article content.

The previous link structure directed users to a non-existent permalink (`/tags/tag-name/`), which was incompatible with the new tag filtering feature.

This change updates the link to correctly point to the **dynamic query filter** page, ensuring that clicking a tag inside an article now correctly redirects to the filtering page (e.g., `/tag/?tag=cloudformation`).