### PR TITLE
Fix: prevent incorrect spacing from breaking production CSS compilation

### DIFF
--- a/assets/css/jekyll-theme-chirpy.scss
+++ b/assets/css/jekyll-theme-chirpy.scss
@@ -1,8 +1,7 @@
 ---
 ---
-
 @use 'main
-{%- if jekyll.environment == ' production ' -%}
+{%- if jekyll.environment == 'production' -%}
   .bundle
 {%- endif -%}
 ';


### PR DESCRIPTION
### 🏷️ Change Type

*Use 'x' to mark the type of change that applies to this Pull Request. This should align with your branch prefix:*

- [ ] `feature/`: New features, enhancements, or improvements.
- [x] `fix/`: Bug fixes or small corrections.
- [ ] `hotfix/`: Urgent fixes applied directly to production.
- [ ] `chore/`: Maintenance tasks or general cleanup (no code logic change).
- [ ] `refactor/`: Restructuring or improving code without changing its behavior.
- [ ] `docs/`: Documentation changes or improvements.
- [ ] `test/`: Adding or updating automated tests.
- [ ] `release/`: Preparing a new release version.
- [ ] `ci/`: Continuous integration, pipeline, or automation scripts.
- [ ] `perf/`: Performance improvements.
- [ ] `style/`: Formatting, indentation, or code style adjustments.

---

### 📝 Description of Changes

This PR resolves a critical bug causing the loss of all styling (CSS) on the site when deployed to GitHub Pages (production environment).

The issue was traced to a strict string comparison failure in the `assets/css/jekyll-theme-chirpy.scss` file:

* The Liquid conditional `{%- if jekyll.environment == ' production ' -%}` contained extraneous whitespace around the word `production`.
* This caused the comparison to fail, resulting in the `.bundle` file (containing the optimized production CSS) not being imported by the SCSS compiler.

This change removes the incorrect spacing, ensuring the production CSS is compiled and loaded correctly when `jekyll.environment` is set to `production`.